### PR TITLE
feat(ci): improve PR triage issue detection

### DIFF
--- a/.github/scripts/find-linked-issue.js
+++ b/.github/scripts/find-linked-issue.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import process from 'node:process';
+import { findLinkedIssue } from '../../scripts/link-utils.js';
+
+async function readStdin() {
+  const chunks = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(typeof chunk === 'string' ? chunk : chunk.toString());
+  }
+  return chunks.join('');
+}
+
+const text = await readStdin();
+const repository = process.env['GITHUB_REPOSITORY'] ?? '';
+const issue = findLinkedIssue(text, repository);
+
+if (issue) {
+  process.stdout.write(issue);
+}

--- a/scripts/link-utils.js
+++ b/scripts/link-utils.js
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Escape special characters in a string for use within a RegExp constructor.
+ */
+function escapeForRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\-]/g, '\\$&');
+}
+
+/**
+ * Attempt to find a linked issue reference within the provided text.
+ *
+ * @param {string} text - The text to search (e.g. PR title + body).
+ * @param {string} repository - The "owner/repo" identifier for the repository.
+ * @returns {string} The matched issue number, or an empty string if not found.
+ */
+export function findLinkedIssue(text, repository) {
+  if (!text) {
+    return '';
+  }
+
+  const search = `${text}`;
+  const patterns = [];
+  const repo = repository?.trim();
+  const keywordPrefix =
+    '(?:fix(?:es|ed)?|close[sd]?|resolve[sd]?|address(?:es|ed)?)\\s*(?:[:\\-=]|is)?\\s*';
+
+  if (repo) {
+    const escapedRepo = escapeForRegex(repo);
+    patterns.push(new RegExp(`https://github\\.com/${escapedRepo}/issues/(\\d+)`, 'i'));
+    patterns.push(new RegExp(`${escapedRepo}#(\\d+)`, 'i'));
+    patterns.push(new RegExp(`${keywordPrefix}${escapedRepo}#(\\d+)`, 'i'));
+    patterns.push(
+      new RegExp(
+        `${keywordPrefix}https://github\\.com/${escapedRepo}/issues/(\\d+)`,
+        'i',
+      ),
+    );
+  }
+
+  patterns.push(new RegExp(`${keywordPrefix}issue\\s+#?(\\d+)`, 'i'));
+  patterns.push(new RegExp(`${keywordPrefix}GH-(\\d+)`, 'i'));
+  patterns.push(/(?:issue|bug)\s+#?(\d+)/i);
+  patterns.push(/GH-(\d+)/i);
+  patterns.push(/#(\d+)/);
+
+  for (const pattern of patterns) {
+    const match = search.match(pattern);
+    if (match && match[1]) {
+      return match[1];
+    }
+  }
+
+  return '';
+}

--- a/scripts/tests/find-linked-issue.test.js
+++ b/scripts/tests/find-linked-issue.test.js
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { findLinkedIssue } from '../link-utils.js';
+
+const REPO = 'google-gemini/gemini-cli';
+
+describe('findLinkedIssue', () => {
+  it('detects simple #number references', () => {
+    expect(findLinkedIssue('Fixes #123', REPO)).toBe('123');
+  });
+
+  it('detects full GitHub issue URLs', () => {
+    const text = 'Addresses https://github.com/google-gemini/gemini-cli/issues/9876';
+    expect(findLinkedIssue(text, REPO)).toBe('9876');
+  });
+
+  it('detects owner/repo#number references', () => {
+    expect(findLinkedIssue('See google-gemini/gemini-cli#42 for details', REPO)).toBe('42');
+  });
+
+  it('detects keyword with issue number without hash', () => {
+    expect(findLinkedIssue('Resolves issue 55', REPO)).toBe('55');
+  });
+
+  it('detects keyword with issue number including hash', () => {
+    expect(findLinkedIssue('Closes issue #789', REPO)).toBe('789');
+  });
+
+  it('detects keyword with GH-notation', () => {
+    expect(findLinkedIssue('Fixes GH-321', REPO)).toBe('321');
+  });
+
+  it('returns empty string when no issue reference exists', () => {
+    expect(findLinkedIssue('No issue linked here', REPO)).toBe('');
+  });
+
+  it('falls back gracefully when repository is missing', () => {
+    expect(findLinkedIssue('Fixes #101', '')).toBe('101');
+  });
+});


### PR DESCRIPTION
## Summary
- add a Node helper and shared utility to detect linked issues from PR titles and bodies
- update the scheduled PR triage script to use the helper with a fallback to the legacy grep logic
- cover the detection logic with Vitest cases for URLs, owner/repo references, GH- notation, and plain numbers

## Testing
- npm run test:scripts
- npx eslint scripts/link-utils.js scripts/tests/find-linked-issue.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d3dc71f2b48321824f9ecf33b64291

## Summary by Sourcery

Add a robust Node-based utility to detect linked GitHub issues and integrate it into the scheduled PR triage script with a fallback to legacy grep patterns.

New Features:
- Introduce link-utils.js and a CLI wrapper to parse various issue reference formats
- Update the scheduled PR triage script to call the new helper and include PR titles in its search

CI:
- Enhance pr-triage.sh to locate Node.js, determine its script directory, and gracefully fall back to grep logic when the helper is unavailable

Tests:
- Add Vitest tests for URL-based, owner/repo, GH-notation, keyword, and plain-number issue detection